### PR TITLE
Add config directory to Woodpecker Agent

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ devture_woodpecker_ci_agent_container_image_force_pull: "{{ devture_woodpecker_c
 devture_woodpecker_ci_agent_container_image_registry_prefix: docker.io/
 
 devture_woodpecker_ci_agent_base_path: "/{{ devture_woodpecker_ci_agent_identifier }}"
+devture_woodpecker_ci_agent_data_dir_path: "{{ devture_woodpecker_ci_agent_base_path }}/data"
 
 devture_woodpecker_ci_agent_docker_socket_path: /var/run/docker.sock
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,6 +9,7 @@
     group: "{{ devture_woodpecker_ci_agent_gid }}"
   with_items:
     - "{{ devture_woodpecker_ci_agent_base_path }}"
+    - "{{ devture_woodpecker_ci_agent_data_dir_path }}"
 
 - name: Ensure Woodpecker CI agent support files created
   ansible.builtin.template:

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -3,5 +3,6 @@ WOODPECKER_GRPC_SECURE={{ devture_woodpecker_ci_agent_config_grpc_secure | to_js
 WOODPECKER_GRPC_VERIFY={{ devture_woodpecker_ci_agent_config_grpc_verify | to_json }}
 WOODPECKER_AGENT_SECRET={{ devture_woodpecker_ci_agent_config_agent_secret }}
 WOODPECKER_LOG_LEVEL={{ devture_woodpecker_ci_agent_config_log_level }}
+WOODPECKER_AGENT_CONFIG_FILE={{ devture_woodpecker_ci_agent_data_dir_path }}/agent.conf
 
 {{ devture_woodpecker_ci_server_container_additional_environment_variables }}

--- a/templates/woodpecker-ci-agent.service.j2
+++ b/templates/woodpecker-ci-agent.service.j2
@@ -21,6 +21,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--network={{ devture_woodpecker_ci_agent_container_network }} \
 			--env-file={{ devture_woodpecker_ci_agent_base_path }}/env \
 			--mount type=bind,src={{ devture_woodpecker_ci_agent_docker_socket_path }},dst=/var/run/docker.sock \
+			--mount type=bind,src={{ devture_woodpecker_ci_agent_data_dir_path }},dst=/data \
 			--tmpfs=/tmp:rw,noexec,nosuid,size=128m \
 			{{ devture_woodpecker_ci_agent_container_image }}
 


### PR DESCRIPTION
We currently start without providing a config directory to the
service, which makes it complain that it can't save its agent.conf
file.  This ultimately means that the agent won't be able to record
its ID (given by the server), which leads to having multiple temporary
"zombie" agents on the server whenever a reconnection happens.