### PR TITLE
Improve devture_woodpecker_ci_agent_config_agent_secret comment

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,12 @@ devture_woodpecker_ci_agent_config_grpc_secure: false
 devture_woodpecker_ci_agent_config_grpc_verify: false
 
 # devture_woodpecker_ci_agent_config_agent_secret controls WOODPECKER_AGENT_SECRET -
-# A shared secret used by server and agents to authenticate communication.
+# This role only supports agent-specific secrets, i.e., it is not recommended to use
+# a shared secret between Woodpecker CI Server and all of its agents.  Please refer to
+# the following upstream documentation in order to learn how to register an agent and
+# obtain a secret for it:
+#
+#   https://woodpecker-ci.org/docs/administration/agent-config#using-agent-token
 devture_woodpecker_ci_agent_config_agent_secret: ''
 
 devture_woodpecker_ci_agent_systemd_required_systemd_services_list: ['docker.service']


### PR DESCRIPTION
Explain that we support agent-specific secrets only, and provide a
link to the upstream documentation explaining how to add an agent and
obtain a secret for it.