### PR TITLE
Fix variables failing playbook

### DIFF
--- a/tasks/validate_config.yml
+++ b/tasks/validate_config.yml
@@ -6,7 +6,5 @@
       You need to define a required configuration setting (`{{ item }}`) for using this role.
   when: "vars[item] == ''"
   with_items:
-    - devture_woodpecker_ci_server_uid
-    - devture_woodpecker_ci_server_gid
     - devture_woodpecker_ci_agent_config_server
     - devture_woodpecker_ci_agent_config_agent_secret

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -4,4 +4,4 @@ WOODPECKER_GRPC_VERIFY={{ devture_woodpecker_ci_agent_config_grpc_verify | to_js
 WOODPECKER_AGENT_SECRET={{ devture_woodpecker_ci_agent_config_agent_secret }}
 WOODPECKER_LOG_LEVEL={{ devture_woodpecker_ci_agent_config_log_level }}
 
-{{ devture_woodpecker_ci_server_container_additional_environment_variables }}
+{{ devture_woodpecker_ci_agent_container_additional_environment_variables }}


### PR DESCRIPTION
There are some variables used in this role that were copied from the CI server role, but they are not actually used here. These variables cause the role to fail when the agent is installed independently from the server. This pull request is intended to change this behavior.